### PR TITLE
Email

### DIFF
--- a/metadata/page/page.personal-criminal-convictions.json
+++ b/metadata/page/page.personal-criminal-convictions.json
@@ -21,6 +21,14 @@
       ],
       "legend": "Do you require information relating to your time spent in prison or on probation?",
       "name": "auto_name__81"
+    },
+    {
+      "_id": "page.personal-criminal-convictions--text.auto_name__21",
+      "_type": "hidden",
+      "label": "output_email",
+      "name": "output_email",
+      "show": true,
+      "value": "SAR.research+branston@digital.justice.gov.uk"
     }
   ],
   "show": {

--- a/metadata/page/page.start.json
+++ b/metadata/page/page.start.json
@@ -18,6 +18,14 @@
       "_id": "page.start--content--2",
       "_type": "content",
       "html": "## Before you start ##\r\n\r\nYou will need to provide some personal details to help us process your request, such as your name, and date of birth.\r\n\r\nYou will also be asked for details relating to your request, such as the location of a probation office or the date of any court cases. The more information you can provide, the quicker we will be able to respond to your request.\r\n\r\nYou will also need: \r\n\r\n* photo ID, such as a passport or driving licence \r\n* proof of address, such a bank statement or utility bill dated in the last 3 months \r\n* If you are requesting information about someone else, photo ID and proof of address for that person plus a signed letter of consent from them\r\n* If you are a solicitor, you will only need a signed letter of consent\r\n"
+    },
+    {
+      "_id": "page.start--text.auto_name__22",
+      "_type": "hidden",
+      "label": "output_email",
+      "name": "output_email",
+      "show": true,
+      "value": "SAR.research+london@digital.justice.gov.uk"
     }
   ],
   "extraComponents": [


### PR DESCRIPTION
It's kind of working... 🤔

There's an output_email hidden field on the start page set to  
SAR.research+london@digital.justice.gov.uk

and another one on the personal criminal convictions page set to 
SAR.research+branston@digital.justice.gov.uk

They work, when there is a configuration variable with the SERVICE_OUTPUT_EMAIL set to {output_email} it uses the value here to send the email as far as I can tell 

Problems -

1. When you go down one track and then back, we need to make sure it gets overwritten on the way through the second time and doesn't stick on the first value

2. It gets output on the check answers page and also in the PDF